### PR TITLE
level: Support multi-line log writes

### DIFF
--- a/level_test.go
+++ b/level_test.go
@@ -21,14 +21,13 @@ func TestLevelFilter(t *testing.T) {
 
 	logger := log.New(filter, "", 0)
 	logger.Print("[WARN] foo")
-	logger.Println("[ERROR] bar")
-	logger.Println("[DEBUG] baz")
-	logger.Println("[WARN] buzz")
+	logger.Println("[ERROR] bar\n[DEBUG] buzz")
+	logger.Println("[DEBUG] baz\n[WARN] buzz\n[DEBUG] fizz")
 
 	result := buf.String()
 	expected := "[WARN] foo\n[ERROR] bar\n[WARN] buzz\n"
 	if result != expected {
-		t.Fatalf("bad: %#v", result)
+		t.Fatalf("wrong result\ngot:\n%s\nwant:\n%s", result, expected)
 	}
 }
 


### PR DESCRIPTION
`LevelFilter` previously assumed that it would always receive writes one line at a time. Although that is the behavior of the `"log"` package itself, log output is sometimes delivered indirectly through other channels. For example, Terraform (and some other HashiCorp software) uses [`mitchellh/panicwrap`](https://github.com/mitchellh/panicwrap) to recognize crashes, which means that log lines are received indirectly through pipe from the `panicwrap` child process, which seems to introduce some additional buffering.

This appears to be the root cause of hashicorp/terraform#6468. Since removing `panicwrap` from Terraform would hurt its user experience, here we instead make `LevelFilter` a little more forgiving to accept multiple messages in a single write as long as messages are never split across
multiple writes.

This does not change the results for callers that are using the `"log"` package directly, and it makes the behavior a little more resilient to other intermediaries processing log output, as long as those intermediaries don't cause any atomic writes to be split into multiple parts before they reach the log writer. That is true for `panicwrap`'s pipes, allowing Terraform's log output to then be filtered correctly in spite of `panicwrap`.
