### PR TITLE
Avoid unnecessary string copy when no log label is specified

### DIFF
--- a/level.go
+++ b/level.go
@@ -26,8 +26,9 @@ type LevelFilter struct {
 	// will be set.
 	Writer io.Writer
 
-	badLevels map[LogLevel]struct{}
-	once      sync.Once
+	badLevels     map[LogLevel]struct{}
+	once          sync.Once
+	maxLenOfLevel int
 }
 
 // Check will check a given line if it would be included in the level
@@ -40,7 +41,7 @@ func (f *LevelFilter) Check(line []byte) bool {
 	x := bytes.IndexByte(line, '[')
 	if x >= 0 {
 		y := bytes.IndexByte(line[x:], ']')
-		if y >= 0 {
+		if y >= 0 && y-1 <= f.maxLenOfLevel {
 			level = LogLevel(line[x+1 : x+y])
 		}
 	}
@@ -78,4 +79,10 @@ func (f *LevelFilter) init() {
 		badLevels[level] = struct{}{}
 	}
 	f.badLevels = badLevels
+
+	for _, level := range f.Levels {
+		if f.maxLenOfLevel < len(level) {
+			f.maxLenOfLevel = len(level)
+		}
+	}
 }


### PR DESCRIPTION
I'm using hashicorp/logutils with a library that requires `log.Logger`. I think it is very useful because we can use it as a library logger. Thank you very much!

However, I noticed a problem when using hashicorp/logutils with the library. If no log level is specified in the library log output, the log level will be considered a huge string and a huge string copy may occur. For example, this can be a problem when logging JSON.

So I introduced a maximum length of log level string to avoid huge string copy. I don't think this fix will cause any functional or performance issues with existing use cases.

In addition, this fix makes it easier to treat logs without a log level as log levels `""`. This is a bit tricky, but it's useful if we're using hashicorp/logutils to handle both our own logs and library logs.
