### PR TITLE
Keep log level filtering when the prefix uses brackets

### DIFF
--- a/level.go
+++ b/level.go
@@ -35,14 +35,35 @@ type LevelFilter struct {
 func (f *LevelFilter) Check(line []byte) bool {
 	f.once.Do(f.init)
 
-	// Check for a log level
+	// Walk successive [..] pairs and only treat a token as the level
+	// when it matches a configured value in Levels. A bracketed prefix
+	// such as "[ app ]" is therefore skipped rather than mistaken for
+	// the level. If no configured level is found, keep unleveled
+	// behavior and pass the line through.
 	var level LogLevel
-	x := bytes.IndexByte(line, '[')
-	if x >= 0 {
-		y := bytes.IndexByte(line[x:], ']')
-		if y >= 0 {
-			level = LogLevel(line[x+1 : x+y])
+	rest := line
+	for {
+		x := bytes.IndexByte(rest, '[')
+		if x < 0 {
+			break
 		}
+		y := bytes.IndexByte(rest[x:], ']')
+		if y < 0 {
+			break
+		}
+		candidate := LogLevel(rest[x+1 : x+y])
+		matched := false
+		for _, l := range f.Levels {
+			if l == candidate {
+				level = candidate
+				matched = true
+				break
+			}
+		}
+		if matched {
+			break
+		}
+		rest = rest[x+y+1:]
 	}
 
 	_, ok := f.badLevels[level]

--- a/level_test.go
+++ b/level_test.go
@@ -32,6 +32,27 @@ func TestLevelFilter(t *testing.T) {
 	}
 }
 
+func TestLevelFilter_PrefixWithBrackets(t *testing.T) {
+	buf := new(bytes.Buffer)
+	filter := &LevelFilter{
+		Levels:   []LogLevel{"DEBUG", "WARN", "ERROR"},
+		MinLevel: "WARN",
+		Writer:   buf,
+	}
+
+	logger := log.New(filter, "[ app ] ", 0)
+	logger.Print("[WARN] foo")
+	logger.Println("[ERROR] bar")
+	logger.Println("[DEBUG] baz")
+	logger.Println("[WARN] buzz")
+
+	result := buf.String()
+	expected := "[ app ] [WARN] foo\n[ app ] [ERROR] bar\n[ app ] [WARN] buzz\n"
+	if result != expected {
+		t.Fatalf("bad: %#v", result)
+	}
+}
+
 func TestLevelFilterCheck(t *testing.T) {
 	filter := &LevelFilter{
 		Levels:   []LogLevel{"DEBUG", "WARN", "ERROR"},


### PR DESCRIPTION
LevelFilter currently treats the first bracketed token as the level. A log prefix that also uses brackets is then treated as a level name and filtering stops working.

Scan later bracketed tokens and only treat a token as a level when it matches a configured level.

Fixes #8